### PR TITLE
Upgrade the dependencies in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,17 @@
   "description": "use lodash functions directly on objects",
   "main": "lodash-prototype.js",
   "dependencies": {
-    "lodash": "~1.3.1"
+    "lodash": "~4.16.2"
   },
   "devDependencies": {
-    "karma": "~0.9.4",
-    "karma-growl-reporter": "~0.0.1",
-    "karma-mocha": "~0.0.3",
-    "karma-safari-launcher": "0.0.3",
-    "karma-opera-launcher": "0.0.2",
-    "bower": "~0.10.0"
+    "bower": "~1.7.9",
+    "karma": "~1.3.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-growl-reporter": "~1.0.0",
+    "karma-mocha": "~1.2.0",
+    "karma-opera-launcher": "1.0.0",
+    "karma-safari-launcher": "1.0.0",
+    "mocha": "^3.1.0"
   },
   "scripts": {
     "test": "node_modules/.bin/karma start"
@@ -24,5 +26,7 @@
     "type": "git",
     "url": "http://github.com/akatov/lodash-prototype.git"
   },
-  "files": ["lodash-prototype.js"]
+  "files": [
+    "lodash-prototype.js"
+  ]
 }


### PR DESCRIPTION
I noticed that your dependencies were out of date, so I took the liberty
of upgrading them.

After upgrading the dependencies, I ran the tests with `npm test` and
they failed.

In order to make the tests run, I had to install some extra
devDependencies:
- _karma-chrome-launcher@^2.0.0_

After adding extra dependencies, I ran the tests with `npm test` and
they passed.

If you're happy with this pull request, go ahead and merge it!

If you have some questions, please ask.

If you're not interested in these changes, just close this pull request.
